### PR TITLE
fix: add an option to control redirect

### DIFF
--- a/command.go
+++ b/command.go
@@ -34,6 +34,7 @@ httpcheck POST www.example.com colors:='["red", "green", "blue"]'`,
 
 	flags := cmd.Flags()
 	flags.BoolVarP(&opts.ShowBody, "body", "b", false, "print response body")
+	flags.BoolVarP(&opts.FollowRedirect, "follow", "F", false, "follow redirects")
 
 	return cmd
 }

--- a/options.go
+++ b/options.go
@@ -22,11 +22,12 @@ func NewDefaultOptions() *Options {
 
 // Options configures httpstat.
 type Options struct {
-	Method  string
-	URL     string
-	Header  http.Header
-	Data    map[string]any
-	timeout time.Duration
+	Method         string
+	URL            string
+	Header         http.Header
+	Data           map[string]any
+	timeout        time.Duration
+	FollowRedirect bool
 
 	ShowBody    bool
 	maxBodySize int

--- a/trace.go
+++ b/trace.go
@@ -109,7 +109,15 @@ func Trace(ctx context.Context, opts *Options) (*Result, error) {
 	}
 	req = req.WithContext(httptrace.WithClientTrace(req.Context(), trace))
 
-	resp, err := http.DefaultClient.Do(req)
+	cli := http.Client{
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+	if opts.FollowRedirect {
+		cli.CheckRedirect = nil
+	}
+	resp, err := cli.Do(req)
 	if err != nil {
 		return nil, err
 	}

--- a/trace_test.go
+++ b/trace_test.go
@@ -34,3 +34,26 @@ func TestTraceHTTP(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "data", string(b))
 }
+
+func TestRaceHTTP_redirect(t *testing.T) {
+	svr1 := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		fmt.Fprint(rw, "data")
+	}))
+	defer svr1.Close()
+	svr2 := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		http.Redirect(rw, req, svr1.URL, http.StatusMovedPermanently)
+	}))
+	defer svr2.Close()
+
+	opts := NewDefaultOptions()
+	opts.URL = svr2.URL
+	r, err := Trace(context.Background(), opts)
+
+	require.NoError(t, err)
+	assert.Equal(t, "301", r.Status)
+
+	opts.FollowRedirect = true
+	r, err = Trace(context.Background(), opts)
+	require.NoError(t, err)
+	assert.Equal(t, "200", r.Status)
+}


### PR DESCRIPTION
HTTP client follows redirect by default, and the tracing result can be confusing when redirected. This changes the default behavior to not follow redirects, and instead, add an option `--follow` to enable redirects. See https://cs.opensource.google/go/go/+/refs/tags/go1.22.2:src/net/http/client.go;l=71-77 for more details about how CheckRedirect works.