### PR TITLE
feat: support form request

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,9 @@ Custom HTTP method, HTTP header, and JSON data:
 ```bash
 $ httpcheck PUT pie.dev/put X-API-Token:123 name=John obj:='{"k": "v"}'
 ```
+
+Sending form data:
+
+```bash
+$ httpcheck PUT pie.dev/put name=john --form 
+```

--- a/args.go
+++ b/args.go
@@ -75,8 +75,16 @@ func ParseArgs(args []string, opts *Options) error {
 		case separatorHeader:
 			opts.Header.Add(k, v)
 		case separatorDataString:
-			opts.Data[k] = v
+			if opts.IsForm {
+				opts.FormData.Add(k, v)
+			} else {
+				opts.Data[k] = v
+			}
 		case separatorDataRawJSON:
+			if opts.IsForm {
+				return fmt.Errorf("cannot use json value type '%s' with --form", arg)
+			}
+
 			var o any
 			if err := json.Unmarshal([]byte(v), &o); err != nil {
 				return fmt.Errorf("'%s' is not a valid json", v)

--- a/args_test.go
+++ b/args_test.go
@@ -16,8 +16,6 @@ func TestParseArg_defaults(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.Equal(t, "http://www.example.com", opts.URL)
-	assert.Equal(t, 1, len(opts.Header))
-	assert.Equal(t, "application/json", opts.Header.Get("Content-Type"))
 }
 
 func TestParseArg_post(t *testing.T) {
@@ -57,6 +55,19 @@ func TestParseArg_json(t *testing.T) {
 	assert.Equal(t, `{"k":[1,2,3]}`, string(b))
 }
 
+func TestParseArg_form(t *testing.T) {
+	args := []string{
+		"https://www.example.com",
+		"k=v",
+	}
+	opts := NewDefaultOptions()
+	opts.IsForm = true
+	err := ParseArgs(args, opts)
+
+	require.NoError(t, err)
+	assert.Equal(t, "k=v", opts.FormData.Encode())
+}
+
 func TestPArseArg_errors(t *testing.T) {
 	cases := []struct {
 		name string
@@ -69,6 +80,10 @@ func TestPArseArg_errors(t *testing.T) {
 		{
 			name: "unknown request item",
 			args: []string{"www.example.com", "unknown"},
+		},
+		{
+			name: "json value type with --form",
+			args: []string{"www.example.com", "k:=[1, 2, 3]", "--form"},
 		},
 	}
 	for _, tc := range cases {

--- a/command.go
+++ b/command.go
@@ -35,6 +35,7 @@ httpcheck POST www.example.com colors:='["red", "green", "blue"]'`,
 	flags := cmd.Flags()
 	flags.BoolVarP(&opts.ShowBody, "body", "b", false, "print response body")
 	flags.BoolVarP(&opts.FollowRedirect, "follow", "F", false, "follow redirects")
+	flags.BoolVarP(&opts.IsForm, "form", "f", false, "serialize data items as form fields")
 
 	return cmd
 }

--- a/options.go
+++ b/options.go
@@ -2,19 +2,17 @@ package main
 
 import (
 	"net/http"
+	"net/url"
 	"time"
 )
-
-const contentTypeJSON = "application/json"
 
 // NewDefaultOptions returns default httpcheck options.
 func NewDefaultOptions() *Options {
 	return &Options{
-		Method: http.MethodGet,
-		Header: http.Header{
-			"Content-Type": []string{contentTypeJSON},
-		},
+		Method:      http.MethodGet,
+		Header:      http.Header{},
 		Data:        make(map[string]any),
+		FormData:    url.Values{},
 		timeout:     time.Second * 10,
 		maxBodySize: 1024,
 	}
@@ -25,9 +23,11 @@ type Options struct {
 	Method         string
 	URL            string
 	Header         http.Header
+	FormData       url.Values
 	Data           map[string]any
 	timeout        time.Duration
 	FollowRedirect bool
+	IsForm         bool
 
 	ShowBody    bool
 	maxBodySize int

--- a/trace.go
+++ b/trace.go
@@ -11,9 +11,16 @@ import (
 	"net/http/httptrace"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/sirupsen/logrus"
+)
+
+const (
+	contentTypeHeader = "Content-Type"
+	contentTypeJSON   = "application/json"
+	contentTypeForm   = "application/x-www-form-urlencoded; charset=utf-8"
 )
 
 // Result is the performance metric returned by Trace function.
@@ -57,6 +64,8 @@ func Trace(ctx context.Context, opts *Options) (*Result, error) {
 			return nil, err
 		}
 		body = bytes.NewBuffer(b)
+	} else if len(opts.FormData) > 0 {
+		body = strings.NewReader(opts.FormData.Encode())
 	}
 
 	req, err := http.NewRequestWithContext(ctx, opts.Method, opts.URL, body)
@@ -64,6 +73,10 @@ func Trace(ctx context.Context, opts *Options) (*Result, error) {
 		return nil, err
 	}
 	req.Header = opts.Header
+	req.Header.Set(contentTypeHeader, contentTypeJSON)
+	if opts.IsForm {
+		req.Header.Set(contentTypeHeader, contentTypeForm)
+	}
 
 	r := &Result{
 		URL: opts.URL,

--- a/trace_test.go
+++ b/trace_test.go
@@ -35,6 +35,24 @@ func TestTraceHTTP(t *testing.T) {
 	assert.Equal(t, "data", string(b))
 }
 
+func TestTraceHTTP_form(t *testing.T) {
+	svr := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		require.NoError(t, req.ParseForm())
+		assert.Equal(t, "k=v", req.Form.Encode())
+	}))
+	defer svr.Close()
+
+	opts := NewDefaultOptions()
+	opts.URL = svr.URL
+	opts.Method = http.MethodPost
+	opts.FormData.Set("k", "v")
+	opts.IsForm = true
+
+	_, err := Trace(context.Background(), opts)
+
+	require.NoError(t, err)
+}
+
 func TestRaceHTTP_redirect(t *testing.T) {
 	svr1 := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		fmt.Fprint(rw, "data")


### PR DESCRIPTION
Adds an option --form/-f to indicate that a request is for sending form data. When enabled, 'Content-Type' header value is updated accordingly, and data items are serialized as form fields.