### PR TITLE
feat: support query params

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,9 @@ Sending form data:
 ```bash
 $ httpcheck PUT pie.dev/put name=john --form 
 ```
+
+Adding query parameters:
+
+```bash
+$ httpcheck PUT pie.dev/put q==search page==1
+```

--- a/args.go
+++ b/args.go
@@ -14,6 +14,7 @@ const (
 	separatorHeader      = ":"
 	separatorDataString  = "="
 	separatorDataRawJSON = ":="
+	separatorQueryParam  = "=="
 )
 
 var (
@@ -23,6 +24,7 @@ var (
 	// ":=" detected before ":"
 	separators = []string{
 		separatorDataRawJSON,
+		separatorQueryParam,
 		separatorHeader,
 		separatorDataString,
 	}
@@ -90,6 +92,8 @@ func ParseArgs(args []string, opts *Options) error {
 				return fmt.Errorf("'%s' is not a valid json", v)
 			}
 			opts.Data[k] = o
+		case separatorQueryParam:
+			opts.QueryParams.Add(k, v)
 		default:
 			return fmt.Errorf("'%s' is not a valid request item", arg)
 		}

--- a/args_test.go
+++ b/args_test.go
@@ -68,6 +68,18 @@ func TestParseArg_form(t *testing.T) {
 	assert.Equal(t, "k=v", opts.FormData.Encode())
 }
 
+func TestParseArg_queryparams(t *testing.T) {
+	args := []string{
+		"https://www.example.com",
+		"k==v",
+	}
+	opts := NewDefaultOptions()
+	err := ParseArgs(args, opts)
+
+	require.NoError(t, err)
+	assert.Equal(t, "k=v", opts.QueryParams.Encode())
+}
+
 func TestPArseArg_errors(t *testing.T) {
 	cases := []struct {
 		name string

--- a/options.go
+++ b/options.go
@@ -13,6 +13,7 @@ func NewDefaultOptions() *Options {
 		Header:      http.Header{},
 		Data:        make(map[string]any),
 		FormData:    url.Values{},
+		QueryParams: url.Values{},
 		timeout:     time.Second * 10,
 		maxBodySize: 1024,
 	}
@@ -25,6 +26,7 @@ type Options struct {
 	Header         http.Header
 	FormData       url.Values
 	Data           map[string]any
+	QueryParams    url.Values
 	timeout        time.Duration
 	FollowRedirect bool
 	IsForm         bool

--- a/trace.go
+++ b/trace.go
@@ -77,6 +77,13 @@ func Trace(ctx context.Context, opts *Options) (*Result, error) {
 	if opts.IsForm {
 		req.Header.Set(contentTypeHeader, contentTypeForm)
 	}
+	q := req.URL.Query()
+	for k, values := range opts.QueryParams {
+		for _, v := range values {
+			q.Add(k, v)
+		}
+	}
+	req.URL.RawQuery = q.Encode()
 
 	r := &Result{
 		URL: opts.URL,

--- a/trace_test.go
+++ b/trace_test.go
@@ -53,6 +53,22 @@ func TestTraceHTTP_form(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestTraceHTTP_queryparams(t *testing.T) {
+	svr := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		assert.Equal(t, "k=v1&k=v2", req.URL.Query().Encode())
+	}))
+	defer svr.Close()
+
+	opts := NewDefaultOptions()
+	opts.URL = svr.URL
+	opts.QueryParams.Add("k", "v1")
+	opts.QueryParams.Add("k", "v2")
+
+	_, err := Trace(context.Background(), opts)
+
+	require.NoError(t, err)
+}
+
 func TestRaceHTTP_redirect(t *testing.T) {
 	svr1 := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		fmt.Fprint(rw, "data")


### PR DESCRIPTION
Adds a request item type that can be used to specify a query parameter. For example, resulting request URL from below command is `URL?q=search`

```bash
$ httpcheck URL q==search
```