### PR TITLE
feat: sort HTTP headers

### DIFF
--- a/printer.go
+++ b/printer.go
@@ -3,7 +3,6 @@ package main
 import (
 	"fmt"
 	"io"
-	"net/http"
 	"os"
 	"strconv"
 	"strings"
@@ -13,8 +12,8 @@ import (
 const tpl = `Connected to {{ cyan .RemoteAddr }} from {{ .LocalAddr }}
 
 {{ green .HTTPVersion }} {{ cyan .Status }}
-{{ range $key, $value := .Header }}
-{{- cyan $key }}: {{ join $value ";" | gray }}
+{{ range $header := .Headers }}
+{{- cyan $header.Name }}: {{ $header.Value | gray }}
 {{ end }}
 
 {{- if .ShowBody }}
@@ -119,7 +118,7 @@ type data struct {
 	LocalAddr   string
 	HTTPVersion string
 	Status      string
-	Header      http.Header
+	Headers     []Header
 
 	BodyString string
 	BodySize   int64
@@ -176,7 +175,7 @@ func PrintResult(r *Result, opts ...PrintOption) error {
 		LocalAddr:   r.LocalAddr,
 		HTTPVersion: r.HTTPVersion,
 		Status:      r.Status,
-		Header:      r.Header,
+		Headers:     r.Headers,
 		Output:      r.Output,
 
 		BodyString:  string(body),

--- a/printer_test.go
+++ b/printer_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"bytes"
-	"net/http"
 	"os"
 	"path/filepath"
 	"testing"
@@ -32,10 +31,10 @@ func TestPrintResult_success(t *testing.T) {
 				LocalAddr:   "192.168.1.1:63917",
 				HTTPVersion: "HTTP/1.1",
 				Status:      "200",
-				Header: http.Header{
-					"Expires":        []string{"-1"},
-					"Content-Ranges": []string{"bytes"},
-					"Server":         []string{"test"},
+				Headers: []Header{
+					{Name: "Content-Ranges", Value: "bytes"},
+					{Name: "Expires", Value: "-1"},
+					{Name: "Server", Value: "test"},
 				},
 				Output:                 "testdata/response_body.txt",
 				MetricDNSLookup:        10,
@@ -52,10 +51,10 @@ func TestPrintResult_success(t *testing.T) {
 				LocalAddr:   "192.168.1.1:63917",
 				HTTPVersion: "HTTP/2.0",
 				Status:      "200",
-				Header: http.Header{
-					"Expires":        []string{"-1"},
-					"Content-Ranges": []string{"bytes"},
-					"Server":         []string{"test"},
+				Headers: []Header{
+					{Name: "Content-Ranges", Value: "bytes"},
+					{Name: "Expires", Value: "-1"},
+					{Name: "Server", Value: "test"},
 				},
 				Output:                 "testdata/response_body.txt",
 				MetricDNSLookup:        10,
@@ -74,10 +73,10 @@ func TestPrintResult_success(t *testing.T) {
 				LocalAddr:   "192.168.1.1:63917",
 				HTTPVersion: "HTTP/2.0",
 				Status:      "200",
-				Header: http.Header{
-					"Expires":        []string{"-1"},
-					"Content-Ranges": []string{"bytes"},
-					"Server":         []string{"test"},
+				Headers: []Header{
+					{Name: "Content-Ranges", Value: "bytes"},
+					{Name: "Expires", Value: "-1"},
+					{Name: "Server", Value: "test"},
 				},
 				Output:                 "testdata/response_body.txt",
 				MetricDNSLookup:        10,
@@ -96,10 +95,10 @@ func TestPrintResult_success(t *testing.T) {
 				LocalAddr:   "192.168.1.1:63917",
 				HTTPVersion: "HTTP/2.0",
 				Status:      "200",
-				Header: http.Header{
-					"Expires":        []string{"-1"},
-					"Content-Ranges": []string{"bytes"},
-					"Server":         []string{"test"},
+				Headers: []Header{
+					{Name: "Content-Ranges", Value: "bytes"},
+					{Name: "Expires", Value: "-1"},
+					{Name: "Server", Value: "test"},
 				},
 				Output:                 "testdata/response_body.txt",
 				MetricDNSLookup:        10,


### PR DESCRIPTION
When printing the final output, PrintResult function iterate over the HTTP headers stored in http.Header which uses map internally. This makes it difficult for a user to parse the Headers in the output since keys in the map are not ordered.

This changes the behavior by using slice instead to store and sort the headers by name and value. Additionally, removes header []value join logic from template.