### PR TITLE
fix: cannot override default headers

### DIFF
--- a/trace.go
+++ b/trace.go
@@ -80,12 +80,17 @@ func Trace(ctx context.Context, opts *Options) (*Result, error) {
 	if err != nil {
 		return nil, err
 	}
-	req.Header = opts.Header
 	req.Header.Set(contentTypeHeader, contentTypeJSON)
 	req.Header.Set(acceptHeader, acceptHeaderValueJSON)
 	if opts.IsForm {
 		req.Header.Set(contentTypeHeader, contentTypeForm)
 		req.Header.Del(acceptHeader)
+	}
+	for k, values := range opts.Header {
+		req.Header.Del(k)
+		for _, v := range values {
+			req.Header.Add(k, v)
+		}
 	}
 	q := req.URL.Query()
 	for k, values := range opts.QueryParams {

--- a/trace_test.go
+++ b/trace_test.go
@@ -123,3 +123,19 @@ func TestTrace_headers(t *testing.T) {
 	}
 	assert.Equal(t, want, got)
 }
+
+func TestTrace_override_default_header(t *testing.T) {
+	svr := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		assert.Equal(t, "*/*", req.Header.Get("Accept"))
+		assert.Equal(t, "text/html", req.Header.Get("Content-Type"))
+	}))
+	defer svr.Close()
+
+	opts := NewDefaultOptions()
+	opts.URL = svr.URL
+	opts.Header.Set("accept", "*/*")
+	opts.Header.Set("content-type", "text/html")
+	_, err := Trace(context.Background(), opts)
+
+	require.NoError(t, err)
+}


### PR DESCRIPTION
Trace function sets Accept and Content-Type headers depending on the type of request data (form or json). The operation can override any custom headers provided by user.

Move the step merging custom headers after setting the default headers to ensure that custom headers are sent.